### PR TITLE
.github/workflows: check go module tidiness

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "*"
+
+env:
+  GOPROXY: "https://proxy.golang.org"
+
+jobs:
+  lint:
+    name: Go Mod Tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check Go module tidiness
+        shell: bash
+        run: |
+          go mod tidy
+          STATUS=$(git status --porcelain go.mod go.sum)
+          if [ ! -z "$STATUS" ]; then
+            echo "Running go mod tidy modified go.mod and/or go.sum"
+            exit 1
+          fi


### PR DESCRIPTION
This is to ensure that changes to `go.mod` or `go.sum` don't break `go mod tidy`.

For verifying changes in PRs like https://github.com/dims/community-images/pull/19.

cc @dims 