### PR TITLE
regex update: added start anchor and trailing "/" to prevent false positives

### DIFF
--- a/cmd/community_images/cli/root.go
+++ b/cmd/community_images/cli/root.go
@@ -70,7 +70,7 @@ func RootCmd() *cobra.Command {
 
 			config, _ := KubernetesConfigFlags.ToRESTConfig()
 			log.Header(headerLine(config.Host))
-			re := regexp.MustCompile(`k8s\.gcr\.io|gcr\.io/google-containers`)
+			re := regexp.MustCompile(`^k8s\.gcr\.io/|^gcr\.io/google-containers`)
 			for _, runningImage := range imagesList {
 				image := imageWithTag(runningImage)
 				log.StartImageLine(image)


### PR DESCRIPTION
added start anchor and **/** to the regex expression

This will cover **k8s.gcr.io.[mirror].io** registries.

possible solves: https://kubernetes.slack.com/archives/CCK68P2Q2/p1677522163886019?thread_ts=1677416006.142059&cid=CCK68P2Q2

